### PR TITLE
Replace redundant explicit move-ctors&move-op= by default

### DIFF
--- a/include/thread_pool/mpsc_bounded_queue.hpp
+++ b/include/thread_pool/mpsc_bounded_queue.hpp
@@ -93,38 +93,13 @@ namespace tp
             Cell(const Cell&) = delete;
             Cell& operator=(const Cell&) = delete;
 
-            Cell(Cell&& rhs)
-                : sequence(rhs.sequence.load()), data(std::move(rhs.data))
-            {
-            }
-
-            Cell& operator=(Cell&& rhs)
-            {
-                sequence = rhs.sequence.load();
-                data = std::move(rhs.data);
-
-                return *this;
-            }
+            Cell(Cell&&) = default;
+            Cell& operator=(Cell&&) = default;
         };
 
     public:
-        MPMCBoundedQueue(MPMCBoundedQueue&& rhs)
-            : m_buffer(std::move(rhs.m_buffer)),
-              m_buffer_mask(std::move(rhs.m_buffer_mask)),
-              m_enqueue_pos(rhs.m_enqueue_pos.load()),
-              m_dequeue_pos(rhs.m_dequeue_pos.load())
-        {
-        }
-
-        MPMCBoundedQueue& operator=(MPMCBoundedQueue&& rhs)
-        {
-            m_buffer = std::move(rhs.m_buffer);
-            m_buffer_mask = std::move(rhs.m_buffer_mask);
-            m_enqueue_pos = rhs.m_enqueue_pos.load();
-            m_dequeue_pos = rhs.m_dequeue_pos.load();
-
-            return *this;
-        }
+        MPMCBoundedQueue(MPMCBoundedQueue&&) = default;
+        MPMCBoundedQueue& operator=(MPMCBoundedQueue&&) = default;
 
     private:
         typedef char Cacheline[64];

--- a/include/thread_pool/thread_pool.hpp
+++ b/include/thread_pool/thread_pool.hpp
@@ -75,19 +75,8 @@ namespace tp
         ThreadPool& operator=(const ThreadPool&) = delete;
 
     public:
-        ThreadPool(ThreadPool&& rhs)
-            : m_workers(std::move(rhs.m_workers)),
-              m_next_worker(rhs.m_next_worker.load())
-        {
-        }
-
-        ThreadPool& operator=(ThreadPool&& rhs)
-        {
-            m_workers = std::move(rhs.m_workers);
-            m_next_worker = rhs.m_next_worker.load();
-
-            return *this;
-        }
+        ThreadPool(ThreadPool&&) = default;
+        ThreadPool& operator=(ThreadPool&&) = default;
 
     private:
         Worker& getWorker();

--- a/include/thread_pool/worker.hpp
+++ b/include/thread_pool/worker.hpp
@@ -65,21 +65,8 @@ namespace tp
         Worker& operator=(const Worker&) = delete;
 
     public:
-        Worker(Worker&& rhs)
-            : m_queue(std::move(rhs.m_queue)),
-              m_running_flag(rhs.m_running_flag.load()),
-              m_thread(std::move(rhs.m_thread))
-        {
-        }
-
-        Worker& operator=(Worker&& rhs)
-        {
-            m_queue = std::move(rhs.m_queue);
-            m_running_flag = rhs.m_running_flag.load();
-            m_thread = std::move(rhs.m_thread);
-
-            return *this;
-        }
+        Worker(Worker&&) = default;
+        Worker& operator=(Worker&&) = default;
 
     private:
         /**


### PR DESCRIPTION
Why not just allow compiler do its job?