### PR TITLE
Conditional variable instead of sleep_for

### DIFF
--- a/cond_variable_instead_sleep_for.patch
+++ b/cond_variable_instead_sleep_for.patch
@@ -1,0 +1,46 @@
+--- worker.hpp	Thu Mar 22 23:20:12 2018
++++ worker.hpp	Sat Mar 24 22:28:13 2018
+@@ -2,6 +2,8 @@
+ 
+ #include <atomic>
+ #include <thread>
++#include <condition_variable>
++#include <mutex>
+ 
+ namespace tp
+ {
+@@ -78,6 +80,8 @@
+     Queue<Task> m_queue;
+     std::atomic<bool> m_running_flag;
+     std::thread m_thread;
++    std::mutex m_conditional_mutex;
++    std::condition_variable m_conditional_lock;
+ };
+ 
+ 
+@@ -121,6 +125,7 @@
+ inline void Worker<Task, Queue>::stop()
+ {
+     m_running_flag.store(false, std::memory_order_relaxed);
++    m_conditional_lock.notify_all();
+     m_thread.join();
+ }
+ 
+@@ -140,6 +145,7 @@
+ template <typename Handler>
+ inline bool Worker<Task, Queue>::post(Handler&& handler)
+ {
++    m_conditional_lock.notify_one();
+     return m_queue.push(std::forward<Handler>(handler));
+ }
+ 
+@@ -171,7 +177,8 @@
+         }
+         else
+         {
+-            std::this_thread::sleep_for(std::chrono::milliseconds(1));
++            std::unique_lock<std::mutex> lock(m_conditional_mutex);
++            m_conditional_lock.wait(lock);
+         }
+     }
+ }


### PR DESCRIPTION
I'm trying to avoid some overhead when pool is idle or underload.

Pls, advice me - is this way correct? Testing shows less overall pool latency, but I'm in doubt - this should not be serialization point for scaling.