### PR TITLE
Use relative header paths instead of absolute paths

### DIFF
--- a/include/thread_pool.hpp
+++ b/include/thread_pool.hpp
@@ -1,3 +1,3 @@
 #pragma once
 
-#include <thread_pool/thread_pool.hpp>
+#include "thread_pool/thread_pool.hpp"

--- a/include/thread_pool/thread_pool.hpp
+++ b/include/thread_pool/thread_pool.hpp
@@ -1,9 +1,9 @@
 #pragma once
 
-#include <thread_pool/fixed_function.hpp>
-#include <thread_pool/mpmc_bounded_queue.hpp>
-#include <thread_pool/thread_pool_options.hpp>
-#include <thread_pool/worker.hpp>
+#include "fixed_function.hpp"
+#include "mpmc_bounded_queue.hpp"
+#include "thread_pool_options.hpp"
+#include "worker.hpp"
 
 #include <atomic>
 #include <memory>

--- a/tests/fixed_function.t.cpp
+++ b/tests/fixed_function.t.cpp
@@ -115,11 +115,11 @@ TEST(FixedFunction, allocDealloc)
     }
 
     ASSERT_EQ(def + cop + mov, destroyed);
-    ASSERT_EQ(2, def);
-    ASSERT_EQ(0, cop);
-    ASSERT_EQ(6, mov);
-    ASSERT_EQ(0, cop_ass);
-    ASSERT_EQ(0, mov_ass);
+    ASSERT_EQ(2llu, def);
+    ASSERT_EQ(0llu, cop);
+    ASSERT_EQ(6llu, mov);
+    ASSERT_EQ(0llu, cop_ass);
+    ASSERT_EQ(0llu, mov_ass);
 }
 
 TEST(FixedFunction, freeFunc)

--- a/tests/thread_pool_options.t.cpp
+++ b/tests/thread_pool_options.t.cpp
@@ -8,7 +8,7 @@ TEST(ThreadPoolOptions, ctor)
 {
     tp::ThreadPoolOptions options;
 
-    ASSERT_EQ(1024, options.queueSize());
+    ASSERT_EQ(1024llu, options.queueSize());
     ASSERT_EQ(std::max<size_t>(1u, std::thread::hardware_concurrency()),
               options.threadCount());
 }
@@ -17,11 +17,11 @@ TEST(ThreadPoolOptions, modification)
 {
     tp::ThreadPoolOptions options;
 
-    options.setThreadCount(5);
-    ASSERT_EQ(5, options.threadCount());
+    options.setThreadCount(5llu);
+    ASSERT_EQ(5llu, options.threadCount());
 
-    options.setQueueSize(32);
-    ASSERT_EQ(32, options.queueSize());
+    options.setQueueSize(32llu);
+    ASSERT_EQ(32llu, options.queueSize());
 }
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
## Description

Use relative paths when including internal header files.

As an added bonus I changed some test literals to clean up warnings when building the tests.

## Why?

By using relative paths the library will work anywhere it might be copied to, without the need for extra build configurations.

I ran into a problem when importing this library in my [benchmark project](https://github.com/rockerbacon/thread-pool-benchmark) because the dependency manager tool I'm using moves the include files to a subfolder inside a fixed include directory (the subfolder is there to avoid name collisions).